### PR TITLE
Fix to focus editor when null

### DIFF
--- a/src/Editor/__test__/editorTest.js
+++ b/src/Editor/__test__/editorTest.js
@@ -14,7 +14,7 @@ describe("Editor test suite", () => {
     ).to.equal("div");
   });
 
-  xit("should have an editorState object in state", () => {
+  it("should have an editorState object in state", () => {
     const editor = shallow(<Editor />);
     assert.isDefined(editor.state().editorState);
     assert.isDefined(editor.state().editorFocused);
@@ -24,4 +24,12 @@ describe("Editor test suite", () => {
     const editor = shallow(<Editor />);
     expect(editor.find(".rdw-editor-toolbar")).to.have.length(1);
   });
+
+  it("should not focus editor when toggle to a second editor", () => {
+    const firstEditor = shallow(<Editor />);
+    const secondEditor = shallow(<Editor />);
+    secondEditor.childAt(1).simulate('click');
+    assert.isDefined(firstEditor.state().editorFocused);
+    assert.isDefined(secondEditor.state().editorFocused);
+  })
 });

--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -347,7 +347,9 @@ class WysiwygEditor extends Component {
 
   focusEditor = () => {
     setTimeout(() => {
-      this.editor.focus();
+      if(this.editor){
+        this.editor.focus();
+      }
     });
   };
 


### PR DESCRIPTION
When removing `Editor` from DOM this error occurs.

![image (4)](https://user-images.githubusercontent.com/42775600/85157902-b1826880-b221-11ea-83b4-bb1a3e85adeb.png)

Checking for the presence of `Editor`.

@flandrade  can you give a view to this one please? 
